### PR TITLE
Add default active scope

### DIFF
--- a/app/admin/listings_admin.rb
+++ b/app/admin/listings_admin.rb
@@ -3,6 +3,11 @@ Trestle.resource(:listings) do
     item :listings, icon: "fa fa-list-alt"
   end
 
+  scopes do
+    scope :active, -> { Listing.active }, default: true
+    scope :all
+  end
+
   # Customize the table columns shown on the index view.
   #
   table do


### PR DESCRIPTION
Add a default active scope to listings.

<img width="296" alt="Screenshot 2020-11-02 at 16 36 17" src="https://user-images.githubusercontent.com/16309691/97893857-b9066200-1d29-11eb-8b93-156fb37ccd65.png">
