### PR TITLE
Force SSL redirection in Production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.


### PR DESCRIPTION
FreeBay is currently accessible via it's non-SSL URL: http://freebay.herokuapp.com  This means that signup and login credentials can be sent without encryption, if a user inadvertantly accesses the site using **http** instead of **https**.

Adding `config.force_ssl = true` is the standard way of enforcing this in a Rails app (i.e. should redirect to any non-SSL requests to https://freebay.herokuapp.com), however, this might be worth testing to make sure that this works on Heroku servers.

See: https://api.rubyonrails.org//classes/ActionDispatch/SSL.html
