### PR TITLE
Add back description to listing show page

### DIFF
--- a/app/views/listings/show.html.erb
+++ b/app/views/listings/show.html.erb
@@ -27,6 +27,12 @@
         <% end %>
 
         <div class="mb-4">
+          <p>
+            <%= markdown @listing.description %>
+          </p>
+        </div>
+
+        <div class="mb-4">
           <%= link_to "Bid now", new_listing_bid_path(@listing), class: "btn btn-primary" %>
         </div>
       <% else %>

--- a/spec/features/listing_spec.rb
+++ b/spec/features/listing_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.feature "UserViewsListing", type: :feature do
+  before do
+    @user = FactoryBot.create(:user)
+    @listing = FactoryBot.create(:listing)
+  end
+
+  scenario 'user logs in and views listing' do
+    visit root_path(as: @user)
+
+    visit listing_path(@listing)
+
+    expect(page).to have_content(@listing.title)
+    expect(page).to have_content(@listing.description)
+
+    expect(page).to have_link("Bid now")
+
+    # make sure the card is displayed
+    expect(page).to have_css 'div.card-body > h5', text: @listing.title
+  end
+end


### PR DESCRIPTION
Listings were showing without their description after the styling updates, so just adding it back in here.

Before:
![image](https://user-images.githubusercontent.com/16309691/110320362-124c0e00-8008-11eb-8863-a32590f980ae.png)
